### PR TITLE
Make Header names case sensitive

### DIFF
--- a/src/common/HTTPRequest.ts
+++ b/src/common/HTTPRequest.ts
@@ -364,14 +364,14 @@ export class HTTPRequest {
     const responseHeaders: Record<string, string> = {};
     if (response.headers) {
       for (const header of Object.keys(response.headers))
-        responseHeaders[header.toLowerCase()] = String(
+        responseHeaders[header] = String(
           response.headers[header]
         );
     }
     if (response.contentType)
-      responseHeaders['content-type'] = response.contentType;
-    if (responseBody && !('content-length' in responseHeaders))
-      responseHeaders['content-length'] = String(
+      responseHeaders['Content-Type'] = response.contentType;
+    if (responseBody && !('Content-Length' in responseHeaders))
+      responseHeaders['Content-Length'] = String(
         Buffer.byteLength(responseBody)
       );
 


### PR DESCRIPTION
According RFC 2616 Header names are not case sensitive but produces an error on some sites